### PR TITLE
fix an extra hyphen

### DIFF
--- a/src/development/building-and-debugging.md
+++ b/src/development/building-and-debugging.md
@@ -34,5 +34,5 @@ fn function_to_debug() {
 Then one can run a test which exercises the code to debug and show the error output via
 
 ```shell,ignore
-./x.py test library/alloc --test-args <test_name> --test-args --no-capture
+./x.py test library/alloc --test-args <test_name> --test-args --nocapture
 ```


### PR DESCRIPTION
There's an extra hyphen on the "run test and show its output" example command, which took me a while to figure out why it wasn't working (especially since the `--no-capture` does nothing instead of erroring).